### PR TITLE
Update for 1.12.1

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
-mc_version=1.12
-forge_version=14.21.1.2387
-mappings=snapshot_20170624
-ccl_version=3.1.2.+
-jei_version=4.7.0.+
-mod_version=2.4.0
+mc_version=1.12.1
+forge_version=14.22.0.2452
+mappings=snapshot_20170916
+ccl_version=3.1.3.+
+jei_version=4.7.7.+
+mod_version=2.4.1


### PR DESCRIPTION
I am relatively new to creating or updating forge mods, but I believe I made the minimum edits to get CodeChickenLib working in Minecraft 1.12.1. I played with a locally compiled version with this patch for about 15 minutes on 1.12.1 today and did not experience any crashing or other issues.