### PR TITLE
Use real name instead of display name

### DIFF
--- a/src/main/java/codechicken/enderstorage/block/BlockEnderStorage.java
+++ b/src/main/java/codechicken/enderstorage/block/BlockEnderStorage.java
@@ -154,7 +154,7 @@ public class BlockEnderStorage extends Block implements ITileEntityProvider {
                 return true;
             } else if (!item.isEmpty() && ItemUtils.areStacksSameTypeCrafting(item, ConfigurationHandler.personalItem)) {
                 if (!owner.frequency.hasOwner()) {
-                    owner.setFreq(owner.frequency.copy().setOwner(player.getDisplayNameString()));
+                    owner.setFreq(owner.frequency.copy().setOwner(player.getName()));
                     if (!player.capabilities.isCreativeMode) {
                         item.shrink(1);
                     }


### PR DESCRIPTION
Using display name allows users to exploit a nickname system (such as ftbutils) to access other private channels.